### PR TITLE
protect users and rentLead routes

### DIFF
--- a/server/api/rentLead.js
+++ b/server/api/rentLead.js
@@ -7,12 +7,16 @@ const {postSlack} = require('../3ps/slack');
 const {validateNum, sendFirstSMS, testSMS} = require('../3ps/sms');
 const {sendFirstEmail} = require('../3ps/email');
 const {loadTestDB} = require('../dev/testDB')
+const auth = require('../middleware/auth')
+const useUnless = require('../middleware/useUnless')
 
 
 const router = express.Router();
 
 //ToDo: change to call to DB once property table is created
 const {propertyNum} = require('../3ps/calandly');
+
+router.use(useUnless(auth, ['/']))
 
 //---------------------------------------------------------- New Lead From Email Parse ----------------------------------------------------------//
 // @route: Post /api/rent_lead;

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -3,9 +3,11 @@ const bcrypt = require('bcryptjs');
 
 const User = require('../db/models/users/User');
 const auth = require('../middleware/auth');
+const useUnless = require('../middleware/useUnless')
 
 const router = express.Router();
 
+router.use(useUnless(auth, ['/', '/login']))
 
 // @route: Post /api/user;
 // @desc: create new user
@@ -27,7 +29,7 @@ router.post('/', async(req,res) => {
 // @route: GET /api/users;
 // @desc: get user by token
 // @ access: Private
-router.get('/',auth, (req,res) => {
+router.get('/', (req,res) => {
   try {
     res.status(201).json(req.user);
   } catch (e) {
@@ -61,7 +63,7 @@ router.post('/login', async (req,res) => {
 // @route: Post /api/users/logout;
 // @desc: log out user
 // @ access: Private
-router.post('/logout', auth, async(req,res) => {
+router.post('/logout', async(req,res) => {
   try {
     req.user.tokens = req.user.tokens.filter((token) => {
       return token.token != req.token;
@@ -78,7 +80,7 @@ router.post('/logout', auth, async(req,res) => {
 // @route: Post /api/users/logout/all;
 // @desc: log out all devices
 // @ access: Private
-router.get('/logout/all', auth, async(req,res) => {
+router.get('/logout/all', async(req,res) => {
   try {
     req.user.tokens = [];
     await req.user.save();

--- a/server/middleware/useUnless.js
+++ b/server/middleware/useUnless.js
@@ -1,0 +1,11 @@
+var useUnless = function(middleware, paths) {
+  return function(req, res, next) {
+      if (paths.includes(req.path)) {
+          return next();
+      } else {
+          return middleware(req, res, next);
+      }
+  };
+};
+
+module.exports = useUnless;


### PR DESCRIPTION
I made the users and rentLead routes private, except the ones marked as public in the comments, please check that they had to be in fact private.
We can privatize other routes easily with the new helper I wrote and with your middleware
