### PR TITLE
Check cookies to avoid flashing of content

### DIFF
--- a/client/src/components/core/Navbar.js
+++ b/client/src/components/core/Navbar.js
@@ -4,8 +4,9 @@ import { connect } from 'react-redux';
 import { logout } from '../../actions/auth'
 import PropTypes from 'prop-types'
 import {loadUser} from '../../actions/auth';
+import {getCookie} from '../../util/cookies'
 
-const Navbar = ({auth:{isAuthenticated, loading}, logout}) => {
+const Navbar = ({auth:{isAuthenticated, loading, loginInProgress}, logout}) => {
     useEffect(() => {
         loadUser();    
     }, [loadUser]);
@@ -34,11 +35,17 @@ const Navbar = ({auth:{isAuthenticated, loading}, logout}) => {
 
     );
 
+    let links = guestLinks
+
+    if(isAuthenticated || (loginInProgress && getCookie('sid'))) {
+      links = authLinks
+    }
+
         
     return (
         <nav className = 'navbar bg-dark'>
             <h2><Link to='/'><i className="fas fa-code"></i> ReThink PM</Link></h2>
-            {!loading && (<Fragment> {isAuthenticated ? authLinks : guestLinks}</Fragment>)}
+            {links}
         </nav>
     )
 }

--- a/client/src/components/core/routing/PrivateRoute.js
+++ b/client/src/components/core/routing/PrivateRoute.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Route, Redirect, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import {getCookie} from '../../../util/cookies'
 
 const PrivateRoute = ({ component: Component, auth: { isAuthenticated, loading, loginInProgress }, ...rest }) => (
     <Route {...rest} render={(props) => renderFunction(Component, props, loginInProgress, isAuthenticated, loading)} />
@@ -9,7 +10,11 @@ const PrivateRoute = ({ component: Component, auth: { isAuthenticated, loading, 
 
 const renderFunction = (Component, props, loginInProgress, isAuthenticated, loading) => {
   if(loginInProgress) {
-    return ''
+    if(getCookie('sid')){
+      return <Component {...props} />
+    } else {
+      return <NotAuthenticatedInfo />
+    }
   }
   if(!isAuthenticated && !loading) {
     return <NotAuthenticatedInfo />

--- a/client/src/util/cookies.js
+++ b/client/src/util/cookies.js
@@ -1,0 +1,4 @@
+export function getCookie(name) {
+  var v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
+  return v ? v[2] : null;
+}


### PR DESCRIPTION
There was a little flash of no content before, because it had to wait for the backend to resolve the user data.
I added a check now, first it checks if the user is loaded, if not it check if there's a cookie named sid in the browser (so we can now at least that the user has logged in in the past), if the cookie exists it shows the component by default.
This change is based also in the route protection one, it really doesn't matter if the show the UI to the user because they won't be able to fetch anything from the backend without the proper auth. And we improve the UX for the logged users as we don't introduce additional delay in our page changes